### PR TITLE
add first try of security scan

### DIFF
--- a/.github/workflows/security-workflow.yml
+++ b/.github/workflows/security-workflow.yml
@@ -1,0 +1,38 @@
+name: scan all images
+
+on:
+  workflow_dispatch:
+        
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ['inseefrlab/onyxia-base:latest', 'inseefrlab/onyxia-base:latest-gpu',
+                 'inseefrlab/onyxia-python:latest', 'inseefrlab/onyxia-python:latest-gpu',
+                 'inseefrlab/onyxia-jupyter-python:latest', 'inseefrlab/onyxia-jupyter-python:latest-gpu',
+                 'inseefrlab/onyxia-vscode-python:latest', 'inseefrlab/onyxia-vscode-python:latest-gpu',
+                 'inseefrlab/onyxia-pyspark:latest', 'inseefrlab/onyxia-pyspark:latest-gpu',
+                 'inseefrlab/onyxia-rstudio:latest', 'inseefrlab/onyxia-rstudio:latest-gpu',
+                 'inseefrlab/onyxia-sparkr:latest', 'inseefrlab/onyxia-sparkr:latest-gpu',
+                 'inseefrlab/onyxia-rstudio-sparkr:latest', 'inseefrlab/onyxia-rstudio-sparkr:latest-gpu']
+    name: scan images
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ matrix.image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          timeout: '30m0s'
+          security-checks: 'vuln'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: matrix.image


### PR DESCRIPTION
#8 
First try probably to be customize.
use trivy action that generate a SARIF file which is a standard file to describe vulnerabilites.
upload sarif file to security code scan of github.

As we have multiple docker images the category option should partition the different file upload.

This first try is based upon latest tag that should change one day.
We could schedule this.