### PR TITLE
Add some dependencies for quarto to run python docs

### DIFF
--- a/python-datascience/environment/lib-datascience.yml
+++ b/python-datascience/environment/lib-datascience.yml
@@ -12,6 +12,8 @@ dependencies:
   - hvac
   - ipykernel
   - matplotlib-base
+  - nbclient
+  - nbformat
   - nltk
   - numba
   - numpy


### PR DESCRIPTION
I propose to add two dependencies that are required if we want `quarto` to be able to process `python` code