### PR TITLE
Install TensorFlow via pip

### DIFF
--- a/.github/workflows/main-workflow-artifact.yml
+++ b/.github/workflows/main-workflow-artifact.yml
@@ -26,7 +26,7 @@ jobs:
       test: true
       push: false
       base_image: ubuntu:20.04
-      base_image_gpu: nvidia/cuda:11.3.1-base-ubuntu20.04
+      base_image_gpu: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
       #debug: true
   python-minimal:
     secrets:

--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       test: true
       push: true
       base_image: ubuntu:20.04
-      base_image_gpu: nvidia/cuda:11.3.1-base-ubuntu20.04
+      base_image_gpu: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
   python-minimal:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/dev/build-chain.py
+++ b/dev/build-chain.py
@@ -25,7 +25,10 @@ if len(sys.argv) == 3:
 for i, image in enumerate(chain):
 
     if image == "base":
-        previous_image = "ubuntu:20.04"
+        if GPU:
+            previous_image = "nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04"
+        else:
+            previous_image = "ubuntu:20.04"
     else:
         previous_image = chain[i-1]
 

--- a/dev/build-chain.py
+++ b/dev/build-chain.py
@@ -5,6 +5,9 @@ import sys
 chains = {
     "rstudio": ["base", "r-minimal", "r-datascience", "rstudio"],
     "rstudio-sparkr": ["base", "r-minimal", "spark", "rstudio"],
+    "python-minimal": ["base", "python-minimal"],
+    "python-datascience": ["base", "python-minimal", "python-datascience"],
+    "python-pyspark": ["base", "python-minimal", "spark"],
     "jupyter-r": ["base", "r-minimal", "r-datascience", "jupyter-r"],
     "jupyter-minimal": ["base", "python-minimal", "jupyter-python"],
     "jupyter-datascience": ["base", "python-minimal", "python-datascience", "jupyter-python"],

--- a/dev/deployment-gpu.yml
+++ b/dev/deployment-gpu.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: python-minimal
-        image: inseefrlab/onyxia-python-minimal:latest-gpu
+        image: inseefrlab/onyxia-python-minimal:dev-gpu
         command: ["sleep", "10000"]
         imagePullPolicy: Always
         resources:

--- a/dev/deployment-gpu.yml
+++ b/dev/deployment-gpu.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: python-minimal
-        image: inseefrlab/python-minimal:latest-gpu
+        image: inseefrlab/onyxia-python-minimal:latest-gpu
         command: ["sleep", "10000"]
         imagePullPolicy: Always
         resources:

--- a/python-tensorflow/Dockerfile
+++ b/python-tensorflow/Dockerfile
@@ -3,18 +3,12 @@ FROM $BASE_IMAGE
 
 SHELL ["/bin/bash", "-c"]
 
-# CPU/GPU
-ARG DEVICE_SUFFIX
-
 USER root
 
-COPY conda-env${DEVICE_SUFFIX}.yml .
-
-RUN mamba env update -n base -f conda-env${DEVICE_SUFFIX}.yml && \
+RUN pip install tensorflow && \
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} && \
     # Clean
-    rm conda-env${DEVICE_SUFFIX}.yml && \ 
     mamba clean --all -f -y
 
 USER ${USERNAME}

--- a/python-tensorflow/conda-env-gpu.yml
+++ b/python-tensorflow/conda-env-gpu.yml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-
-dependencies:
-  - cudatoolkit=11.6
-  - tensorflow==2.6.0=cuda112* # works with any cudatoolkit>=11.2

--- a/python-tensorflow/conda-env.yml
+++ b/python-tensorflow/conda-env.yml
@@ -1,5 +1,0 @@
-channels:
-  - conda-forge
-
-dependencies:
-  - tensorflow-cpu


### PR DESCRIPTION
- Install TensorFlow via pip to avoid conflicts in package versions when using conda
- Change base GPU image to `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04` to have `cudnn` installed by default