### PR TITLE
let R_VERSION be overrided by ARG and not ENV

### DIFF
--- a/r-minimal/Dockerfile
+++ b/r-minimal/Dockerfile
@@ -5,6 +5,7 @@ SHELL ["/bin/bash", "-c"]
 
 # R Config
 ARG R_VERSION="4.2.1"
+ENV R_VERSION="${R_VERSION}"
 ENV R_HOME="/usr/local/lib/R"
 ENV DEFAULT_USER="${USERNAME}"
 

--- a/r-minimal/Dockerfile
+++ b/r-minimal/Dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE
 SHELL ["/bin/bash", "-c"]
 
 # R Config
-ENV R_VERSION="4.2.1"
+ARG R_VERSION="4.2.1"
 ENV R_HOME="/usr/local/lib/R"
 ENV DEFAULT_USER="${USERNAME}"
 


### PR DESCRIPTION
In order to let the strong and robust pipeline build different version of R, the R image should allow docker buildargs to override default value R_VERSION