### PR TITLE
Add jupyter-cache to environment

### DIFF
--- a/python-datascience/conda-env.yml
+++ b/python-datascience/conda-env.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - gensim
   - geopandas
+  - jupyter-cache
   - matplotlib-base
   - nltk
   - numba


### PR DESCRIPTION
To be able to use the `cache` feature in conda (https://quarto.org/docs/projects/code-execution.html#cache), we need the `jupyter-cache` package