### PR TITLE
Use varenv to set pip/conda/R repositories

### DIFF
--- a/base/common-scripts/onyxia-init.sh
+++ b/base/common-scripts/onyxia-init.sh
@@ -135,6 +135,19 @@ if [[ -e "/usr/local/lib/R/etc/" ]]; then
     fi
     env | grep "KUBERNETES" >> /usr/local/lib/R/etc/Renviron.site
     env | grep "IMAGE_NAME" >> /usr/local/lib/R/etc/Renviron.site
+    
+    if [[ -n "$R_REPOSITORY" ]]; then
+        echo "configuration r (TODO)"
+        # To indent a heredoc, <<- and tabs are required (no spaces allowed)
+        cat <<-EOF >> /usr/local/lib/R/etc/Rprofile.site
+		# Proxy repository for R
+		local({
+			r <- getOption("repos")
+			r["LocalRepository"] <- "${R_REPOSITORY}"
+			options(repos = r)
+		})
+		EOF
+    fi
 fi
 
 if [[ -n "$PERSONAL_INIT_SCRIPT" ]]; then
@@ -148,6 +161,15 @@ if [[ -e "$HOME/work" ]]; then
   else
     echo "cd $HOME/work" >> $HOME/.bashrc
   fi
+fi
+
+if [[ -n "$PIP_REPOSITORY" ]]; then
+    echo "configuration pip (index-url)"
+    pip config set global.index-url $PIP_REPOSITORY
+fi
+if [[ -n "$CONDA_REPOSITORY" ]]; then
+    echo "configuration conda (add channels)"
+    conda config --add channels $CONDA_REPOSITORY
 fi
 
 echo "execution of $@"

--- a/base/common-scripts/onyxia-init.sh
+++ b/base/common-scripts/onyxia-init.sh
@@ -137,7 +137,7 @@ if [[ -e "/usr/local/lib/R/etc/" ]]; then
     env | grep "IMAGE_NAME" >> /usr/local/lib/R/etc/Renviron.site
     
     if [[ -n "$R_REPOSITORY" ]]; then
-        echo "configuration r (TODO)"
+        echo "configuration r (add local repository)"
         # To indent a heredoc, <<- and tabs are required (no spaces allowed)
         cat <<-EOF >> /usr/local/lib/R/etc/Rprofile.site
 		# Proxy repository for R


### PR DESCRIPTION
In order to use the images in environments which require the use of a proxy repository (Nexus, Artifactory, ...), an option could be to react to the presnece of specific environment variables in order to make the necessary actions to use such proxy repositories.

This PR proposes the uses of these three environment variables, following the tools actually used in the various images : 

- PIP_REPOSITORY
- CONDA_REPOSITORY
- R_REPOSITORY

The actual implementation behind "using the proxy repositories" is completely open for change. Namely, here are two things that come to mind : 

- For PIP, we chose to use the `pip config set` command ; another possibility [according to the documentation](https://pip.pypa.io/en/stable/topics/configuration/#environment-variables) could be to create a PIP_INDEX_URL environment variable. I don't have the necessary experience to see if one option is better than the other.
- For the R repository, the only implementation we could think of was to append to a configuration file parsed by R. For readability, this was implemented with a heredoc... but at the cost of using tabulations for the relevant lines (see also : https://unix.stackexchange.com/a/76483). This also means that any auto-linting tool could remove said tabs, and break the configuration in doing so. If you feel this is a somewhat decent risk, then maybe we need to think of another way of implementing this.