### PR TITLE
Add path to ca bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![Main manual workflow with artefacts](https://github.com/InseeFrLab/images-datascience/actions/workflows/main-workflow-artifact.yml/badge.svg?branch=main)](https://github.com/InseeFrLab/images-datascience/actions/workflows/main-workflow-artifact.yml)
 
 # images-datascience
-A collection of Docker images for ready-to-run datascience services
+A collection of Docker images for ready-to-run datascience services.
+
+They could be used alone and are designed to work with Onyxia ecosystem.
 
 ## conception of this images
 
@@ -42,13 +44,18 @@ A collection of Docker images for ready-to-run datascience services
 
 List of environment variable you can use to pimp the container at init:
 
+If helm chart support is checked, it means that environment variable behavior is supported in https://github.com/InseeFrLab/helm-charts-interactive-services
 
-|   environment variable   |   Example | Description |  helm chart support |   Onyxia region support   |
+If Onyxia support is checked, it means that the Onyxia product could inject automatically the environment variable based on onyxia-web behavior or onyxia-api region configuration.
+
+
+|   environment variable   |   Example | Description |  helm chart support |   Onyxia support   |
 |---    |:-:    |:-:    |:-:    |:-:     |
-| PIP_REPOSITORY   | "https://some.entreprise.mirror/repository/pypi-proxy/simple"   | Configure an externally managed pip repository manager   | ✔️   | not yet   |
-| CONDA_REPOSITORY | https://some.entreprise.mirror/repository/conda-proxy/main   |  Configure an externally managed conda repository manager   |✔️     |not yet     |
-| PATH_TO_CA_BUNDLE  | /etc/ssl/certs/ca-certificates.crt  | Configure a path to a ca bundle with autorities to support an auto-signed some.entreprise.mirror   | not yet    | not yet     |
+| PIP_REPOSITORY   | "https://some.entreprise.mirror/repository/pypi-proxy/simple"   | Configure an externally managed pip repository manager   | ✔️   | not yet (*)  |
+| CONDA_REPOSITORY | https://some.entreprise.mirror/repository/conda-proxy/main   |  Configure an externally managed conda repository manager   |✔️   | not yet  (*)   |
+| PATH_TO_CA_BUNDLE  | /etc/ssl/certs/ca-certificates.crt  | Configure a path to a ca bundle with autorities to support an auto-signed some.entreprise.mirror   | not yet    | not yet (*)    |
 
+(*) For now you should inject this another way, contact on onyxia slack for some recipes depend of your context.
 
 ## Freshness and rebuild
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ A collection of Docker images for ready-to-run datascience services
       classDef package fill:#3cb5f2 ,color:#000  ;
       classDef ide fill:#0072d9  ;
 ```
+## Environment variable
+
+List of environment variable you can use to pimp the container at init:
+
+
+|   environment variable   |   Example | Description |  helm chart support |   Onyxia region support   |
+|---    |:-:    |:-:    |:-:    |:-:     |
+| PIP_REPOSITORY   | "https://some.entreprise.mirror/repository/pypi-proxy/simple"   | Configure an externally managed pip repository manager   | ✔️   | not yet   |
+| CONDA_REPOSITORY | https://some.entreprise.mirror/repository/conda-proxy/main   |  Configure an externally managed conda repository manager   |✔️     |not yet     |
+| PATH_TO_CA_BUNDLE  | /etc/ssl/certs/ca-certificates.crt  | Configure a path to a ca bundle with autorities to support an auto-signed some.entreprise.mirror   | not yet    | not yet     |
+
 
 ## Freshness and rebuild
 

--- a/base/common-scripts/onyxia-init.sh
+++ b/base/common-scripts/onyxia-init.sh
@@ -172,5 +172,12 @@ if [[ -n "$CONDA_REPOSITORY" ]]; then
     conda config --add channels $CONDA_REPOSITORY
 fi
 
+if [[ -n "$PATH_TO_CA_BUNDLE" ]]; then
+    echo "configuration of pip and conda to a custom crt"
+    pip config set global.cert $PATH_TO_CA_BUNDLE
+    conda config --set ssl_verify $PATH_TO_CA_BUNDLE
+fi
+
+
 echo "execution of $@"
 exec "$@"


### PR DESCRIPTION
PATH_TO_CA_BUNDLE env variable could inject a path to a crt that contains authority for pip and conda when pointing on an autosigned enteprise package manager like nexus or artifactory.

We could use it by injecting with some tools like gatekeeper/kyverno but we could also for next steps:
- add helm chart supports (giving a value override this env variable)
- add onyxia injection support (giving a region configuration inject this path).

Being here the certificat support had to be handle by some injection process with external tools.

To go further:
- the helm chart could support a liste of ca to add a configmap with crt mounted in a Path referenced by PATH_To_CA_BUNDLE
- onyxia could inject this list of ca in region configuration.
