### PR TITLE
RStudio : correction on RProfile.site file if a proxy repository is configured

### DIFF
--- a/base/common-scripts/onyxia-init.sh
+++ b/base/common-scripts/onyxia-init.sh
@@ -144,7 +144,9 @@ if [[ -e "/usr/local/lib/R/etc/" ]]; then
     if [[ -n "$R_REPOSITORY" ]]; then
         echo "configuration r (add local repository)"
         # To indent a heredoc, <<- and tabs are required (no spaces allowed)
-        cat <<-EOF >> /usr/local/lib/R/etc/Rprofile.site
+        cat <<-EOF > /usr/local/lib/R/etc/Rprofile.site
+		# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux
+		options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])))
 		# Proxy repository for R
 		local({
 			r <- getOption("repos")
@@ -152,6 +154,7 @@ if [[ -e "/usr/local/lib/R/etc/" ]]; then
 			options(repos = r)
 		})
 		EOF
+
     fi
 fi
 


### PR DESCRIPTION
After further testing of the RStudio image behind a proxy repository, I found that the configuration I suggested in https://github.com/InseeFrLab/images-datascience/pull/64 was not ideal. In its current state, RStudio first tries to download packages from the builtin repository (https://packagemanager.rstudio.com/cran at the time of the writing), and only tries the proxy repository after this one times out.

To change this behavior, this PR suggests rewriting the whole `/usr/local/lib/R/etc/R/Rprofile.site` file (instead of appending to it). The line that appears to have been added in the file changes was present in the original file, which was the following for reference : 

```
options(repos = c(CRAN = 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest'), download.file.method = 'libcurl')
# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux
options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])))
# Proxy repository for R
local({
r <- getOption("repos")
r["LocalRepository"] <- "*** REDACTED INTERNAL PROXY REPOSITORY ***"
options(repos = r)
})
```