### PR TITLE
Use pip to install PyTorch instead of Conda

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -57,7 +57,7 @@ jobs:
     with:
       image: python-pytorch
       context: python-pytorch
-      test: false
+      test: true
       base_image: python-minimal
       python_version_1: 3.9.13
       python_version_2: 3.10.4
@@ -195,7 +195,7 @@ jobs:
     with:
       image: jupyter-pytorch
       context: jupyter
-      test: false
+      test: true
       base_image: python-pytorch
       python_version_1: 3.9.13
       python_version_2: 3.10.4
@@ -210,7 +210,7 @@ jobs:
     with:
       image: vscode-pytorch
       context: vscode
-      test: false
+      test: true
       base_image: python-pytorch
       python_version_1: 3.9.13
       python_version_2: 3.10.4

--- a/python-pytorch/Dockerfile
+++ b/python-pytorch/Dockerfile
@@ -10,7 +10,7 @@ USER root
 
 COPY conda-env${DEVICE_SUFFIX}.yml .
 
-RUN mamba env update -n base -f conda-env${DEVICE_SUFFIX}.yml && \
+RUN pip install torch torchvision torchaudio && \
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} && \
     # Clean

--- a/python-pytorch/Dockerfile
+++ b/python-pytorch/Dockerfile
@@ -8,13 +8,10 @@ ARG DEVICE_SUFFIX
 
 USER root
 
-COPY conda-env${DEVICE_SUFFIX}.yml .
-
 RUN pip install torch torchvision torchaudio && \
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} && \
     # Clean
-    rm conda-env${DEVICE_SUFFIX}.yml && \ 
     mamba clean --all -f -y
 
 USER 1000

--- a/python-pytorch/conda-env-gpu.yml
+++ b/python-pytorch/conda-env-gpu.yml
@@ -1,9 +1,0 @@
-channels:
-  - pytorch
-  - nvidia
-
-dependencies:
-  - pytorch
-  - torchaudio
-  - torchvision
-  - pytorch-cuda=11.7

--- a/python-pytorch/conda-env.yml
+++ b/python-pytorch/conda-env.yml
@@ -1,8 +1,0 @@
-channels:
-  - pytorch
-
-dependencies:
-  - pytorch
-  - torchvision
-  - torchaudio
-  - cpuonly


### PR DESCRIPTION
Reduces by a few GBs the size of the Python-PyTorch images with GPU support.