### PR TITLE
Add package required for R Support in VSCode

### DIFF
--- a/r-python-julia/Dockerfile
+++ b/r-python-julia/Dockerfile
@@ -23,9 +23,6 @@ RUN wget -O - https://raw.githubusercontent.com/rocker-org/rocker-versioned2/R4.
     rm requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 
-# Required for R support to work in VSCode
-RUN R -e "install.packages('languageserver')"
-
 USER 1000
 
 CMD ["/bin/bash"]

--- a/r-python-julia/Dockerfile
+++ b/r-python-julia/Dockerfile
@@ -23,6 +23,9 @@ RUN wget -O - https://raw.githubusercontent.com/rocker-org/rocker-versioned2/R4.
     rm requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 
+# Required for R support to work in VSCode
+RUN R -e "install.packages('languageserver')"
+
 USER 1000
 
 CMD ["/bin/bash"]

--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -22,7 +22,8 @@ RUN curl -fsSL https://code-server.dev/install.sh | bash && \
         code-server --install-extension ms-python.python; \
     fi && \
     if command -v R; then \
-        code-server --install-extension reditorsupport.r; \
+        code-server --install-extension reditorsupport.r && \
+        R -e "install.packages('languageserver')"; \
     fi && \
     if command -v julia; then \
         code-server --install-extension julialang.language-julia; \


### PR DESCRIPTION
The VSCode documentation for R Support indicates that the following steps are required:

1. [Install R](https://cloud.r-project.org/) (>= 3.4.0) for your platform. For Windows users, it is recommended to check Save version number in registry during installation so that the R extension can find the R executable automatically.
2. Install [languageserver](https://github.com/REditorSupport/languageserver) in R.
```r
install.packages("languageserver")
```
3. Install the [R extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r).
4. Create an R file and start coding.

Step 2 was missing which throws the following warning when the user starts to use R:
![image](https://user-images.githubusercontent.com/3328347/220197719-aa6cada0-fd3c-48b2-ab25-4ffd8e09a326.png)

I just added one line to install the corresponding package. 

**Disclaimer**: I did not test this line on this specific Dockerfile as it would imply to re-write several of the Github action yamls. However I use it [on a Dockerimage that is a child of this one](https://github.com/fBedecarrats/docker_pa_matching/blob/main/Dockerfile) and it works fine.