### PR TITLE
'postgresql' instead of 'postgresql-client'

### DIFF
--- a/scripts/install-system-libs.sh
+++ b/scripts/install-system-libs.sh
@@ -22,7 +22,7 @@ apt_install \
     locales \
     nano \
     openssh-client \
-    postgresql-client \
+    postgresql \
     sudo \
     tini \
     unzip \


### PR DESCRIPTION
In order to use the `psql` command, we need to have the package `postgresql`, not the `postgresql-client` as explained in this thread : https://stackoverflow.com/questions/56309597/what-is-the-difference-between-psql-and-postgresql-client