### PR TITLE
Make use of PACKAGE_MANAGER_URL env variable

### DIFF
--- a/scripts/onyxia-init.sh
+++ b/scripts/onyxia-init.sh
@@ -148,25 +148,6 @@ if command -v R; then
     fi
     env | grep "KUBERNETES" >> ${R_HOME}/etc/Renviron.site
     env | grep "IMAGE_NAME" >> ${R_HOME}/etc/Renviron.site
-    
-    if [[ -n "$R_REPOSITORY" ]]; then
-        echo "configuration r (add local repository)"
-        # To indent a heredoc, <<- and tabs are required (no spaces allowed)
-        cat <<-EOF > ${R_HOME}/etc/Rprofile.site
-		# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux
-		options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])))
-		# Proxy repository for R
-		local({
-			r <- getOption("repos")
-			r["LocalRepository"] <- "${R_REPOSITORY}"
-			options(repos = r)
-		})
-		EOF
-
-    fi
-
-    # Configure renv to use the specified package repository
-    echo 'options(renv.config.repos.override = getOption("repos"))' >> ${R_HOME}/etc/Rprofile.site
 fi
 
 if [[ -e "$HOME/work" ]]; then
@@ -175,36 +156,6 @@ if [[ -e "$HOME/work" ]]; then
   else
     echo "cd $HOME/work" >> $HOME/.bashrc
   fi
-fi
-
-if [  "`which pip`" != "" ]; then
-    if [[ -n "$PIP_REPOSITORY" ]]; then
-        echo "configuration pip (index-url)"
-        pip config set global.index-url $PIP_REPOSITORY
-    fi
-    if [[ -n "$PATH_TO_CA_BUNDLE" ]]; then
-        echo "configuration of pip to a custom crt"
-        pip config set global.cert $PATH_TO_CA_BUNDLE
-    fi
-fi
-
-if [  "`which conda`" != "" ]; then
-    if [[ -n "$CONDA_REPOSITORY" ]]; then
-        echo "configuration conda (add channels)"
-        conda config --add channels $CONDA_REPOSITORY
-        conda config --remove channels conda-forge
-        conda config --remove channels conda-forge --file /opt/mamba/.condarc
-    fi
-    if [[ -n "$PATH_TO_CA_BUNDLE" ]]; then
-        echo "configuration of conda to a custom crt"
-        conda config --set ssl_verify $PATH_TO_CA_BUNDLE
-    fi
-fi
-
-if [  "`which python`" != "" ]; then
-    if [ -n "$PATH_TO_CA_BUNDLE" ]; then
-        python /opt/certifi_ca.py
-    fi 
 fi
 
 if [[ -n "$FAUXPILOT_SERVER" ]]; then
@@ -218,6 +169,10 @@ if [[ -n "$PERSONAL_INIT_SCRIPT" ]]; then
     echo "download $PERSONAL_INIT_SCRIPT"
     curl $PERSONAL_INIT_SCRIPT | bash -s -- $PERSONAL_INIT_ARGS
 fi
+
+# The commands related to setting the various repositories (R/CRAN, pip, conda)
+# are located in specific script
+source onyxia-set-repositories.sh
 
 echo "execution of $@"
 exec "$@"

--- a/scripts/onyxia-init.sh
+++ b/scripts/onyxia-init.sh
@@ -165,14 +165,14 @@ if [[ -n "$FAUXPILOT_SERVER" ]]; then
     jq --arg key "fauxpilot.enabled" --argjson value "true" --indent 4 '. += {($key): $value}'  $dir/$file > $dir/$file.tmp && mv $dir/$file.tmp $dir/$file
 fi
 
+# The commands related to setting the various repositories (R/CRAN, pip, conda)
+# are located in specific script
+source onyxia-set-repositories.sh
+
 if [[ -n "$PERSONAL_INIT_SCRIPT" ]]; then
     echo "download $PERSONAL_INIT_SCRIPT"
     curl $PERSONAL_INIT_SCRIPT | bash -s -- $PERSONAL_INIT_ARGS
 fi
-
-# The commands related to setting the various repositories (R/CRAN, pip, conda)
-# are located in specific script
-source onyxia-set-repositories.sh
 
 echo "execution of $@"
 exec "$@"

--- a/scripts/onyxia-set-repositories.sh
+++ b/scripts/onyxia-set-repositories.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+if [  "`which pip`" != "" ]; then
+    if [[ -n "$PIP_REPOSITORY" ]]; then
+        echo "configuration pip (index-url)"
+        pip config set global.index-url $PIP_REPOSITORY
+    fi
+
+    if [[ -n "$PATH_TO_CA_BUNDLE" ]]; then
+        echo "configuration of pip to a custom crt"
+        pip config set global.cert $PATH_TO_CA_BUNDLE
+    fi
+fi
+
+if [  "`which conda`" != "" ]; then
+    if [[ -n "$CONDA_REPOSITORY" ]]; then
+        echo "configuration conda (add channels)"
+        conda config --add channels $CONDA_REPOSITORY
+        conda config --remove channels conda-forge
+        conda config --remove channels conda-forge --file /opt/mamba/.condarc
+    fi
+
+    if [[ -n "$PATH_TO_CA_BUNDLE" ]]; then
+        echo "configuration of conda to a custom crt"
+        conda config --set ssl_verify $PATH_TO_CA_BUNDLE
+    fi
+fi
+
+if [  "`which python`" != "" ]; then
+    python /opt/certifi_ca.py
+fi
+
+if command -v R; then
+  if [[ -n "$R_REPOSITORY" ]] || [[ -n "$PACKAGE_MANAGER_URL" ]]; then
+      echo "configuration r (add local repository)"
+
+      echo '# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux' > ${R_HOME}/etc/Rprofile.site
+      echo 'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])))' >> ${R_HOME}/etc/Rprofile.site
+      echo '# Proxy repository for R' >> ${R_HOME}/etc/Rprofile.site
+      echo 'local({' >> ${R_HOME}/etc/Rprofile.site
+      echo '  r <- getOption("repos")' >> ${R_HOME}/etc/Rprofile.site
+
+      if [[ -n "$PACKAGE_MANAGER_URL" ]]; then
+          UBUNTU_CODENAME=$(cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -d= -f2)
+          echo "  r[\"PackageManager\"] <- \"${PACKAGE_MANAGER_URL}/${UBUNTU_CODENAME}/latest\"" >> ${R_HOME}/etc/Rprofile.site
+      fi 
+
+      if [[ -n "$R_REPOSITORY" ]]; then
+          echo "  r[\"LocalRepository\"] <- \"${R_REPOSITORY}\"" >> ${R_HOME}/etc/Rprofile.site
+      fi 
+      
+      echo '  options(repos = r)' >> ${R_HOME}/etc/Rprofile.site
+      echo '})' >> ${R_HOME}/etc/Rprofile.site
+
+      # Unsure if this last line below should be inside this is ; 
+      # leaving it here for now, but should be reviewed before.
+
+      # Configure renv to use the specified package repository
+      echo 'options(renv.config.repos.override = getOption("repos"))' >> ${R_HOME}/etc/Rprofile.site
+  fi
+
+fi

--- a/scripts/onyxia-set-repositories.sh
+++ b/scripts/onyxia-set-repositories.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [  "`which pip`" != "" ]; then
     if [[ -n "$PIP_REPOSITORY" ]]; then
         echo "configuration pip (index-url)"
@@ -47,7 +47,7 @@ if command -v R; then
       if [[ -n "$R_REPOSITORY" ]]; then
           echo "  r[\"LocalRepository\"] <- \"${R_REPOSITORY}\"" >> ${R_HOME}/etc/Rprofile.site
       fi 
-      
+
       echo '  options(repos = r)' >> ${R_HOME}/etc/Rprofile.site
       echo '})' >> ${R_HOME}/etc/Rprofile.site
 


### PR DESCRIPTION
Linked to a couple of PRs on the helm charts : 

- https://github.com/InseeFrLab/helm-charts-interactive-services/pull/76
- https://github.com/InseeFrLab/helm-charts-interactive-services/pull/77

This PR changes a couple changes a couple of things related to repository configuration : 

- First, as the PR title implies, it makes use of the PACKAGE_MANAGER_URL that we can manage through Onyxia region and the interactive services helm charts. This way, it's possible to configure both a local instance for Posit Package Manager, and another repository, for instance for in-house packages that need to stay away from the PPM instance for whatever reason.
- Second, all the stuff related to repository configuration (for R/CRAN, pip and conda) was moved to a dedicated `onyxia-set-repositories.sh` file, which in turn is now called in `onyxia-init.sh`. The main purpose for this was to ease "private" rebuilding of these images. As might be common for other users rebuilding their own custom images, we needed to run the repository configuration at build time, and not only runtime. Because of this, we managed a script ripped from `onyxia-init.sh` containing all the pertaining commands. By having a dedicated file "upstream", we can just call the file which will have been baked in the image already.

⚠️  There are a fair number of points I'm not sure about though, please take them into account when reviewing : 

- I couldn't be sure of what exactly was related to repository management. I made a couple of assumptions (stated below), and if case some are wrong, please let me know so I can move the related parts back in `onyxia-init.sh` : 
  - Managing custom certificate authority (`PATH_TO_CA_BUNDLE` and `certifi_ca.py`)
  - Setting the R repositories for renv (the `renv.config.repos.override`) - I don't know if this should be done *only* when we set R_REPOSITORY and/or PACKAGE_MANAGER_URL, or all the time.
- The shebang for `onyxia-init.sh` is `#!/usr/bin/env bash`, but I naively went for a "basic" `#!/bin/bash` in `onyxia-set-repositories.sh`. Is that fine, or should I align with `onyxia-init.sh` ? I'm not sure what this implies.
- This is not actually related to the changes of this PR, but I was wondering why in the Dockerfile, `onyxia-init.sh` was explicitly chmodded even though its containing directory was recursively chmodded just a few lines prior (see the first and last lines in this excerpt : https://github.com/InseeFrLab/images-datascience/blob/main/base/Dockerfile#L31-L77)