### PR TITLE
Use an absolute path for onyxia-set-repositories.sh

### DIFF
--- a/scripts/onyxia-init.sh
+++ b/scripts/onyxia-init.sh
@@ -167,7 +167,7 @@ fi
 
 # The commands related to setting the various repositories (R/CRAN, pip, conda)
 # are located in specific script
-source onyxia-set-repositories.sh
+source /opt/onyxia-set-repositories.sh
 
 if [[ -n "$PERSONAL_INIT_SCRIPT" ]]; then
     echo "download $PERSONAL_INIT_SCRIPT"


### PR DESCRIPTION
Follow-up to #128 to fix a sad oversight on my end : not using an absolute path for script file that manages the R/pip/conda repositories. This in turn leads to the rstudio-based pods to not be able to run it, eg : 

```
λ kubectl logs pod/rstudio-167940-0

    start of onyxia-init.sh script en tant que :
    root
    sudo_allowed
    Cluster "in-cluster" set.
    User "user" set.
    Context "in-cluster" created.
    Switched to context "in-cluster".
    base64: invalid input
    configuration of git to a custom crt
    /usr/local/bin/R
    Renviron.site detected
!!  /opt/onyxia-init.sh: line 170: onyxia-set-repositories.sh: No such file or directory
    execution of /init
    [ ... ]
```

(by the way, there seems to be a problem with a base64 command, according to the above output, though this is out this PR's scope)