### PR TITLE
fix(python): use `conda clean` instead of `mamba clean`

### DIFF
--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -18,9 +18,10 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
     # Set specified Python version in base Conda env
 
-RUN mamba install python=="${PYTHON_VERSION}" && \
+RUN mamba install python=="${PYTHON_VERSION}"
+    
     # Pin Python version to prevent Conda from upgrading it
-    touch ${MAMBA_DIR}/conda-meta/pinned && \
+RUN touch ${MAMBA_DIR}/conda-meta/pinned && \
     echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
     # Install essential Python packages
     # mamba env update -n base -f conda-env.yml && \
@@ -29,7 +30,9 @@ RUN mamba install python=="${PYTHON_VERSION}" && \
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
     # Clean
-    rm miniforge.sh conda-env.yml
+    rm miniforge.sh conda-env.yml && \ 
+    mamba clean --all -f -y && \
+    rm -rf /var/lib/apt/lists/*
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -13,9 +13,9 @@ USER root
 
 COPY conda-env.yml .
 
-RUN wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh -O mambaforge.sh && \
+RUN wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \
     # Install mambaforge latest version
-    /bin/bash mambaforge.sh -b -p "${MAMBA_DIR}" && \
+    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}" && \
     # Set specified Python version in base Conda env
     mamba install python=="${PYTHON_VERSION}" && \
     # Pin Python version to prevent Conda from upgrading it

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -15,25 +15,22 @@ COPY conda-env.yml .
 
 RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O miniforge.sh && \
     # Install mambaforge latest version
-    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
+    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}" && \
     # Set specified Python version in base Conda env
-
-RUN mamba install python=="${PYTHON_VERSION}"
-    
+    mamba install python=="${PYTHON_VERSION}" && \
     # Pin Python version to prevent Conda from upgrading it
-RUN touch ${MAMBA_DIR}/conda-meta/pinned && \
+    touch ${MAMBA_DIR}/conda-meta/pinned && \
     echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
     # Install essential Python packages
-    # mamba env update -n base -f conda-env.yml && \
+    mamba env update -n base -f conda-env.yml && \
     # Activate custom Conda env by default in shell
     echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
     # Clean
     rm miniforge.sh conda-env.yml && \ 
+    conda clean --all -f -y && \
     rm -rf /var/lib/apt/lists/*
-
-RUN conda clean --all -f -y
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -15,22 +15,7 @@ COPY conda-env.yml .
 
 RUN wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \
     # Install mambaforge latest version
-    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}" && \
-    # Set specified Python version in base Conda env
-    mamba install python=="${PYTHON_VERSION}" && \
-    # Pin Python version to prevent Conda from upgrading it
-    touch ${MAMBA_DIR}/conda-meta/pinned && \
-    echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
-    # Install essential Python packages
-    mamba env update -n base -f conda-env.yml && \
-    # Activate custom Conda env by default in shell
-    echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
-    # Fix permissions
-    chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
-    # Clean
-    rm miniforge.sh conda-env.yml && \ 
-    mamba clean --all -f -y && \
-    rm -rf /var/lib/apt/lists/*
+    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -17,20 +17,7 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     # Install mambaforge latest version
     /bin/bash miniforge.sh -b -p "${MAMBA_DIR}" && \
     # Set specified Python version in base Conda env
-    mamba install python=="${PYTHON_VERSION}" && \
-    # Pin Python version to prevent Conda from upgrading it
-    touch ${MAMBA_DIR}/conda-meta/pinned && \
-    echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
-    # Install essential Python packages
-    # mamba env update -n base -f conda-env.yml && \
-    # Activate custom Conda env by default in shell
-    echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
-    # Fix permissions
-    chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
-    # Clean
-    rm miniforge.sh conda-env.yml && \ 
-    mamba clean --all -f -y && \
-    rm -rf /var/lib/apt/lists/*
+    mamba install python=="${PYTHON_VERSION}"
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -33,6 +33,8 @@ RUN touch ${MAMBA_DIR}/conda-meta/pinned && \
     rm miniforge.sh conda-env.yml && \ 
     rm -rf /var/lib/apt/lists/*
 
+RUN mamba clean --all -f -y
+
 USER 1000
 
 CMD ["python3"]

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -29,7 +29,7 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
     # Clean
     rm mambaforge.sh conda-env.yml && \ 
-    # mamba clean --all -f -y && \
+    mamba clean --all -f -y && \
     rm -rf /var/lib/apt/lists/*
 
 USER 1000

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -15,9 +15,23 @@ COPY conda-env.yml .
 
 RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O miniforge.sh && \
     # Install mambaforge latest version
-    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}" && \
+    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
     # Set specified Python version in base Conda env
-    mamba install python=="${PYTHON_VERSION}"
+
+RUN mamba install python=="${PYTHON_VERSION}" && \
+    # Pin Python version to prevent Conda from upgrading it
+    touch ${MAMBA_DIR}/conda-meta/pinned && \
+    echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
+    # Install essential Python packages
+    # mamba env update -n base -f conda-env.yml && \
+    # Activate custom Conda env by default in shell
+    echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
+    # Fix permissions
+    chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
+    # Clean
+    rm miniforge.sh conda-env.yml && \ 
+    mamba clean --all -f -y && \
+    rm -rf /var/lib/apt/lists/*
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -18,20 +18,7 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
     # Set specified Python version in base Conda env
 
-RUN mamba install python=="${PYTHON_VERSION}" && \
-    # Pin Python version to prevent Conda from upgrading it
-    touch ${MAMBA_DIR}/conda-meta/pinned && \
-    echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
-    # Install essential Python packages
-    # mamba env update -n base -f conda-env.yml && \
-    # Activate custom Conda env by default in shell
-    echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
-    # Fix permissions
-    chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
-    # Clean
-    rm miniforge.sh conda-env.yml && \ 
-    mamba clean --all -f -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN mamba install python=="${PYTHON_VERSION}"
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -28,7 +28,7 @@ RUN wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Mi
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
     # Clean
-    rm mambaforge.sh conda-env.yml && \ 
+    rm miniforge.sh conda-env.yml && \ 
     mamba clean --all -f -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -22,7 +22,7 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     touch ${MAMBA_DIR}/conda-meta/pinned && \
     echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
     # Install essential Python packages
-    mamba env update -n base -f conda-env.yml && \
+    # mamba env update -n base -f conda-env.yml && \
     # Activate custom Conda env by default in shell
     echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
     # Fix permissions

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -18,7 +18,18 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
     # Set specified Python version in base Conda env
 
-RUN mamba install python=="${PYTHON_VERSION}"
+RUN mamba install python=="${PYTHON_VERSION}" && \
+    # Pin Python version to prevent Conda from upgrading it
+    touch ${MAMBA_DIR}/conda-meta/pinned && \
+    echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
+    # Install essential Python packages
+    # mamba env update -n base -f conda-env.yml && \
+    # Activate custom Conda env by default in shell
+    echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
+    # Fix permissions
+    chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
+    # Clean
+    rm miniforge.sh conda-env.yml
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -31,7 +31,6 @@ RUN touch ${MAMBA_DIR}/conda-meta/pinned && \
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
     # Clean
     rm miniforge.sh conda-env.yml && \ 
-    mamba clean --all -f -y && \
     rm -rf /var/lib/apt/lists/*
 
 USER 1000

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -33,7 +33,7 @@ RUN touch ${MAMBA_DIR}/conda-meta/pinned && \
     rm miniforge.sh conda-env.yml && \ 
     rm -rf /var/lib/apt/lists/*
 
-RUN mamba clean --all -f -y
+RUN conda clean --all -f -y
 
 USER 1000
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -28,7 +28,7 @@ RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/M
     # Fix permissions
     chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
     # Clean
-    rm mambaforge.sh conda-env.yml && \ 
+    rm miniforge.sh conda-env.yml && \ 
     mamba clean --all -f -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -13,9 +13,24 @@ USER root
 
 COPY conda-env.yml .
 
-RUN wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \
+RUN wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O miniforge.sh && \
     # Install mambaforge latest version
-    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}"
+    /bin/bash miniforge.sh -b -p "${MAMBA_DIR}" && \
+    # Set specified Python version in base Conda env
+    mamba install python=="${PYTHON_VERSION}" && \
+    # Pin Python version to prevent Conda from upgrading it
+    touch ${MAMBA_DIR}/conda-meta/pinned && \
+    echo "python==${PYTHON_VERSION}" >> ${MAMBA_DIR}/conda-meta/pinned && \
+    # Install essential Python packages
+    mamba env update -n base -f conda-env.yml && \
+    # Activate custom Conda env by default in shell
+    echo ". ${MAMBA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc && \
+    # Fix permissions
+    chown -R ${USERNAME}:${GROUPNAME} ${HOME} ${MAMBA_DIR} && \
+    # Clean
+    rm mambaforge.sh conda-env.yml && \ 
+    # mamba clean --all -f -y && \
+    rm -rf /var/lib/apt/lists/*
 
 USER 1000
 


### PR DESCRIPTION
Fixes a weird bug when using `mamba clean`, probably introduced by [conda 23.11](https://github.com/conda/conda/releases/tag/23.11.0)