### PR TITLE
onyxia-init.sh / repositories : use appending redirection (fix for DARK_MODE transmission)

### DIFF
--- a/scripts/onyxia-set-repositories.sh
+++ b/scripts/onyxia-set-repositories.sh
@@ -31,7 +31,7 @@ if command -v R; then
   if [[ -n "$R_REPOSITORY" ]] || [[ -n "$PACKAGE_MANAGER_URL" ]]; then
       echo "configuration r (add local repository)"
 
-      echo '# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux' > ${R_HOME}/etc/Rprofile.site
+      echo '# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux' >> ${R_HOME}/etc/Rprofile.site
       echo 'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])))' >> ${R_HOME}/etc/Rprofile.site
       echo '# Proxy repository for R' >> ${R_HOME}/etc/Rprofile.site
       echo 'local({' >> ${R_HOME}/etc/Rprofile.site


### PR DESCRIPTION
Some users of our in-house deployed Onyxia reported that the dark mode was not correctly propagated to RStudio based images. It appears this is due to the way these images are configured with the `onyxia-init.sh` and `onyxia-set-repositories.sh` scripts. 

Prior to https://github.com/InseeFrLab/images-datascience/pull/148, only the `onyxia-set-repositories.sh` file had some logic related to managing the `${R_HOME}/etc/Rprofile.site` file, and as such, used standard redirection (`>`) to initialize the file.

Since #148, `onyxia-init.sh` now has precedence in modifying this file... but these modifications are then lost (overwritten) by the `onyxia-set-repositories.sh` instructions when a custom repository is configured.

This one-character PR just changes the first instruction in `onyxia-set-repositories.sh` to use *append* redirection (`>>`) instead of the standard one, in hope of fixing this problem.