### PR TITLE
fix(rstudio) : add conda activation only for services where it is installed

### DIFF
--- a/scripts/onyxia-init.sh
+++ b/scripts/onyxia-init.sh
@@ -227,8 +227,8 @@ if [[ -n "$PERSONAL_INIT_SCRIPT" ]]; then
 fi
 
 # Activate Conda env by default in shell except if specified otherwise
-if [[ "$CUSTOM_PYTHON_ENV" != "true" ]]; then
-echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc ;
+if [[ -n "$CONDA_DIR" && "$CUSTOM_PYTHON_ENV" != "true" ]]; then
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate" >> ${HOME}/.bashrc ;
 fi
 
 echo "execution of $@"


### PR DESCRIPTION
verify if CONDA_DIR exists before adding conda activation in .bashrc