### PR TITLE
Stay in the work directory after git clone in the Onyxia init script

### DIFF
--- a/scripts/onyxia-init.sh
+++ b/scripts/onyxia-init.sh
@@ -120,7 +120,6 @@ if [  "`which git`" != "" ]; then
                         chown -R $PROJECT_USER:$PROJECT_GROUP $f
                     fi
                 done
-                cd $HOME  
             fi
         fi
     fi


### PR DESCRIPTION
Hi,

We realized that, when configuring a git repository to clone in a jupyter service in Onyxia, we were not in the same directory (~$HOME/work) as if we don't.

This is because of the removed line in the PR.

Regards.