### PR TITLE
Add predefined mc endpoint for anonymous access

### DIFF
--- a/base/scripts/onyxia-init.sh
+++ b/base/scripts/onyxia-init.sh
@@ -82,6 +82,7 @@ fi
 
 if command -v mc &>/dev/null; then
     export MC_HOST_s3=https://$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY:$AWS_SESSION_TOKEN@$AWS_S3_ENDPOINT
+    export MC_HOST_anon=https://$AWS_S3_ENDPOINT
 fi
 
 if [[ $(id -u) = 0 ]]; then


### PR DESCRIPTION
Sharing files accross buckets is done by setting the anonymous access policy to allow (conditioned) `s3:ListBucket` and `s3:GetObject` access. Accessing such files must then be done through anonymous access (authenticated access fails).

This endpoint allows to simply do `mc cp anon/foreign-bucket/path/to/file.parquet ./`