### PR TITLE
remove ENV_FILE = /etc/environnement for root image

### DIFF
--- a/base/scripts/onyxia-set-repositories.sh
+++ b/base/scripts/onyxia-set-repositories.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ $SUDO -eq 0 ]]; then
-    ENV_FILE=/etc/environment
-else
-    ENV_FILE=${HOME}/.bashrc
-fi
+ENV_FILE=${HOME}/.bashrc
 
 # Python configuration
 


### PR DESCRIPTION
Adding variables to `/etc/environment` does not seem to work if done via this command
`source /opt/onyxia-set-repositories.sh`

Simply adding them to .bashrc seems sufficient