### PR TITLE
Unpin vscode version

### DIFF
--- a/vscode/scripts/install-vscode.sh
+++ b/vscode/scripts/install-vscode.sh
@@ -4,7 +4,7 @@ set -e
 # Install code-server
 wget -q https://code-server.dev/install.sh
 chmod +x install.sh
-./install.sh --version 4.100.3
+./install.sh
 rm install.sh
 
 # Clean install files


### PR DESCRIPTION
#294 introduced a version-pinning for vscode to prevent a regression tied to the webview rendering.  
It has apparently been solved shortly afterwards upstream (https://github.com/coder/code-server/releases/tag/v4.101.2) and multiple versions have been released eversince.  
This PR removes the version-pinning