### PR TITLE
R repositories : moving to "/bin/linux"-style URLs when using PACKAGE_MANAGER_URL

### DIFF
--- a/base/scripts/onyxia-set-repositories.sh
+++ b/base/scripts/onyxia-set-repositories.sh
@@ -30,18 +30,11 @@ if command -v R &>/dev/null; then
   if [[ -n "$R_REPOSITORY" ]] || [[ -n "$PACKAGE_MANAGER_URL" ]]; then
       echo "configuration r (add local repository)"
 
-      # /!\ Possible regression point for other users depending on this code.
-      # The rocker image used as base injects a repository based on the CRAN environment variable, see for instance
-      # https://github.com/rocker-org/rocker-versioned2/blob/677573589638617e04cad971ceafef84d5004f10/scripts/setup_R.sh#L34
-      # This behavior might be unwanted when using an internal repository (eg: Nexus) instead of the public Posit
-      # Package Manager instance. As such, when the PACKAGE_MANAGER_URL variable is set, we should overwrite
-      # the Rprofile.site instead of appending to it. But as there might be unforeseen use cases where this
-      # change could trigger problems, so I'm flagging this as such.
+      # When the PACKAGE_MANAGER_URL variable is set, overwrite the Rprofile.site originating from the rocker image
+      # (but still keep the UserAgent setting in case some internal repositories need it)
       if [[ -n "$PACKAGE_MANAGER_URL" ]]; then
         echo '# Rocker default configuration removed by /opt/onyxia-set-repositories.sh' > ${R_HOME}/etc/Rprofile.site
 
-        # The unwanted behavior is setting options("repos"), but we might want to keep the user agent change from Rocker,
-        # as this can potentially be used depending on how the local package manager is configured.
         echo '# https://docs.rstudio.com/rspm/admin/serving-binaries/#binaries-r-configuration-linux' >> ${R_HOME}/etc/Rprofile.site
         echo 'options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])))' >> ${R_HOME}/etc/Rprofile.site
       fi
@@ -53,11 +46,8 @@ if command -v R &>/dev/null; then
       if [[ -n "$PACKAGE_MANAGER_URL" ]]; then
 
         UBUNTU_CODENAME=$(cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -d= -f2)
-        # Moving from "/__linux__/" style URLs to "/bin/linux" style URLS for PACKAGE_MANAGER_URL,
-        # as this allows easier management for local package managers (at least Nexus, where it allows
-        # using a single repository as opposed to one per major.minor version of R)
+        # Using "/bin/linux" style URLS for PACKAGE_MANAGER_URL allows easier management for local package managers (eg: Nexus)
         # See also : https://docs.posit.co/rspm/admin/serving-binaries.html#using-linux-binary-packages
-        #echo "  r[\"PackageManager\"] <- \"${PACKAGE_MANAGER_URL}/${UBUNTU_CODENAME}/latest\"" >> ${R_HOME}/etc/Rprofile.site
         echo "  r[\"PackageManager\"] <- sprintf(\"${PACKAGE_MANAGER_URL}/latest/bin/linux/${UBUNTU_CODENAME}-%s/%s\", R.version[\"arch\"], substr(getRversion(), 1, 3))" >> ${R_HOME}/etc/Rprofile.site
       fi
 


### PR DESCRIPTION
Hello,

Here's a PR to tweak the behavior of `onyxia-set-repositories.sh` regarding R repositories specifically. Namely, the intent is replace the `/__linux__/` style URLs with the `/bin/linux`, as this allows for better management when using third-party internal repositories (for instance, Sonatype Nexus). For more info on Linux binary resolution on Posit Package Manager, [see this link](https://docs.posit.co/rspm/admin/serving-binaries.html#using-linux-binary-packages).

To explain in detail, when using the former style, it's necessary to use one Nexus repository per major.minor version of R (as we need to set the User-Agent matching the R version on a per-repository basis - even if the agent is set on the R client side, it's lost when Nexus tries to proxy Posit Package Manager). When using the latter style, we can use just one Nexus repository to proxy all the different architectures (both in terms of versions of R and Linux distributions).

But as simple as the change is, it might be a breaking change in its current state, for two reasons : 

- The rstudio image is based on the rocker image, which [forcibly configures a repository based on the CRAN environment variable](https://github.com/rocker-org/rocker-versioned2/blob/16d6d94ee3e936b1bd55fc1f611c8adcc2c08fca/scripts/setup_R.sh#L34), which in turn [is set here to a `/__linux__/` style URL here](https://github.com/InseeFrLab/images-datascience/blob/302ad17b06be69883aec2ee5734fd176f6dd7109/r-minimal/Dockerfile#L11). This is probably desirable for users *not* using an internal repository, and assuming we should leave this untouched, we then have to "reset" this when actually using the `PACKAGE_MANAGER_URL` - this PR is implemented as such, but this is a new behavior which might lead to regression for some users (I can't see any obvious use case, but that doesn't mean there isn't any).
- The very fact that I'm suggesting to change from one style of URL to the other means that other people using the images straight from https://hub.docker.com/r/inseefrlab but just adding the `PACKAGE_MANAGER_URL` variable would need to change the value for that variable. Pre-PR, the value could have been something like `https://mypackagemanager.domain.com/r-packages/__linux__`, but if the PR is accepted as is, the value would need to change to `https://mypackagemanager.domain.com/r-packages`

As such, any suggestion that could transform this in a non-breaking change is more than welcome. Or otherwise, this PR can also be closed, we can still implement the necessary changes on our in-house rebuild of the images.

Thanks !