### PR TITLE
vscode:adding-formatter-extensions-r-python

### DIFF
--- a/vscode/scripts/install-vscode-extensions.sh
+++ b/vscode/scripts/install-vscode-extensions.sh
@@ -42,6 +42,7 @@ done
 python_extensions=(
     "ms-python.python"
     "ms-python.flake8"
+    "charliermarsh.ruff"
 )
 if command -v python &> /dev/null; then
     for extension in "${python_extensions[@]}"; do
@@ -55,6 +56,7 @@ fi
 r_extensions=(
     "reditorsupport.r"
     "RDebugger.r-debugger"
+    "Posit.air-vscode"
 )
 if command -v R &> /dev/null; then
     # Install R kernel for jupyter notebooks


### PR DESCRIPTION
Adding rust-based extensions for python and r. 

- python: [ruff](https://docs.astral.sh/ruff/editors/setup/#vs-code) 
- r: [air](https://tidyverse.org/blog/2025/02/air/)

closing #336 