### PR TITLE
Fix DuckDB CLI install on ARM64

### DIFF
--- a/base/scripts/install-duckdb-cli.sh
+++ b/base/scripts/install-duckdb-cli.sh
@@ -10,7 +10,7 @@ case $ARCH in
         FILENAME="duckdb_cli-linux-amd64.zip"
         ;;
     "aarch64")
-        FILENAME="duckdb_cli-linux-aarch64.zip"
+        FILENAME="duckdb_cli-linux-arm64.zip"
         ;;
     *)
         echo "Unsupported architecture: $ARCH"


### PR DESCRIPTION
- uname -m returns aarch64 on Linux ARM, but DuckDB’s release asset is named duckdb_cli-linux-arm64.zip.
- The install script previously tried to download duckdb_cli-linux-aarch64.zip from releases/latest, which 404s on recent releases and breaks ARM builds.
- This change maps aarch64 to duckdb_cli-linux-arm64.zip