### PR TITLE
fix: kubectl install command

### DIFF
--- a/base/scripts/install-kubectl.sh
+++ b/base/scripts/install-kubectl.sh
@@ -16,7 +16,7 @@ case $ARCH in
         ;;
 esac
 
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"linux/$ARCHITECTURE/kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$ARCHITECTURE/kubectl"
 chmod +x ./kubectl
 mv ./kubectl /usr/local/bin/kubectl
 echo 'source <(kubectl completion bash)' >> ${HOME}/.bashrc


### PR DESCRIPTION
The previously used URL doesn't seem to be maintained anymore, as the `stable.txt` filed used evaluated to `v1.31.0`.

The URL I replaced them with come from the install documentation : https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux

~~⚠️ For now the `amd64` architecture is hardcoded in the URL. Do the images need to cater for other architectures like arm64, or is this good enough ?~~ Nevermind, just saw we had the architecture variable inside, I'll just substitute that instead in a second commit.