### PR TITLE
Improve Git repository authentication handling

### DIFF
--- a/base/scripts/onyxia-init.sh
+++ b/base/scripts/onyxia-init.sh
@@ -95,6 +95,8 @@ if command -v git &>/dev/null; then
         REPO_DOMAIN=$(echo "$GIT_REPOSITORY" | awk -F/ '{print $3}')
         if [ "$REPO_DOMAIN" = "github.com" ]; then
             GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
+        elif echo "$GIT_REPOSITORY" | grep -qi "bitbucket"; then
+            GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_USER_NAME:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
         else
             GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|oauth2:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
         fi

--- a/base/scripts/onyxia-init.sh
+++ b/base/scripts/onyxia-init.sh
@@ -92,14 +92,15 @@ if command -v git &>/dev/null; then
     fi
     if [[ -n "$GIT_REPOSITORY" ]]; then
         if [[ -n "$GIT_PERSONAL_ACCESS_TOKEN" ]]; then
-        REPO_DOMAIN=$(echo "$GIT_REPOSITORY" | awk -F/ '{print $3}')
-        if [ "$REPO_DOMAIN" = "github.com" ]; then
+            REPO_DOMAIN=$(echo "$GIT_REPOSITORY" | awk -F/ '{print $3}')
+            if [ "$REPO_DOMAIN" = "github.com" ]; then
+                GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
             GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
-        elif echo "$GIT_REPOSITORY" | grep -qi "bitbucket"; then
-            GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_USER_NAME:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
-        else
-            GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|oauth2:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
-        fi
+            elif echo "$GIT_REPOSITORY" | grep -qi "bitbucket"; then
+                GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_USER_NAME:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
+            else
+                GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|oauth2:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
+            fi
         fi
 
         if [[ -n "$GIT_BRANCH" ]]; then

--- a/base/scripts/onyxia-init.sh
+++ b/base/scripts/onyxia-init.sh
@@ -92,12 +92,12 @@ if command -v git &>/dev/null; then
     fi
     if [[ -n "$GIT_REPOSITORY" ]]; then
         if [[ -n "$GIT_PERSONAL_ACCESS_TOKEN" ]]; then
-            REPO_DOMAIN=`echo "$GIT_REPOSITORY" | awk -F/ '{print $3}'`
-            if [ $REPO_DOMAIN = "github.com" ]; then
-                GIT_REPOSITORY=`echo $GIT_REPOSITORY | sed "s/$REPO_DOMAIN/$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN/"`
-            else
-                GIT_REPOSITORY=`echo $GIT_REPOSITORY | sed "s/$REPO_DOMAIN/oauth2:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN/"`
-            fi
+        REPO_DOMAIN=$(echo "$GIT_REPOSITORY" | awk -F/ '{print $3}')
+        if [ "$REPO_DOMAIN" = "github.com" ]; then
+            GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
+        else
+            GIT_REPOSITORY=$(echo "$GIT_REPOSITORY" | sed "s|$REPO_DOMAIN|oauth2:$GIT_PERSONAL_ACCESS_TOKEN@$REPO_DOMAIN|")
+        fi
         fi
 
         if [[ -n "$GIT_BRANCH" ]]; then


### PR DESCRIPTION
We run Onyxia in an environment where repositories are hosted across GitHub, GitLab, and Bitbucket. While testing the init script, we found that cloning from Bitbucket instances did not work correctly because the authentication pattern differs from GitHub and GitLab.

This change adds a Bitbucket-specific authentication pattern (username:token@host) so that repositories hosted on Bitbucket can be cloned successfully.

It also changes the sed delimiter from / to | when rewriting the repository URL. Using / caused issues when tokens contained characters that conflicted with the delimiter.

These changes were tested in our environment and cloning now works correctly for GitHub, GitLab, and Bitbucket repositories.