### PR TITLE
Fix ownership patch on filenames with spaces

### DIFF
--- a/base/scripts/onyxia-init.sh
+++ b/base/scripts/onyxia-init.sh
@@ -215,7 +215,7 @@ fi
 echo "Fixing ownership in project directory: $ROOT_PROJECT_DIRECTORY"
 for f in "$ROOT_PROJECT_DIRECTORY"/*; do
     if [[ -d "$f" && "$(basename $f)" != "lost+found" ]]; then
-        chown -R ${USERNAME}:${GROUPNAME} $f
+        chown -R ${USERNAME}:${GROUPNAME} "$f"
     fi
 done
 


### PR DESCRIPTION
We have a script that add files to the root project directory when a container starts.
Some of these files have spaces in their names and the fixing ownership part of the `onyxia-init.sh` script fails on them.

This pull request encloses filenames in double quotes to handle spaces.