### PR TITLE
Add marimo as IDE

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -248,3 +248,45 @@ jobs:
       python_version_1: 3.13.13
       build_gpu: false
     secrets: inherit
+  marimo-python:
+    needs: [python-datascience]
+    uses: ./.github/workflows/main-workflow-template.yml
+    with:
+      image: marimo-python
+      context: marimo
+      base_image: python-datascience
+      python_version_1: 3.13.13
+      python_version_2: 3.12.13
+    secrets: inherit
+  marimo-pyspark:
+    needs: [pyspark]
+    uses: ./.github/workflows/main-workflow-template.yml
+    with:
+      image: marimo-pyspark
+      context: marimo
+      base_image: pyspark
+      python_version_1: 3.13.13
+      python_version_2: 3.12.13
+      spark_version: 4.0.1
+      build_gpu: false
+    secrets: inherit
+  marimo-pytorch:
+    needs: [python-pytorch]
+    uses: ./.github/workflows/main-workflow-template.yml
+    with:
+      image: marimo-pytorch
+      context: marimo
+      base_image: python-pytorch
+      python_version_1: 3.13.13
+      python_version_2: 3.12.13
+    secrets: inherit
+  marimo-tensorflow:
+    needs: [python-tensorflow]
+    uses: ./.github/workflows/main-workflow-template.yml
+    with:
+      image: marimo-tensorflow
+      context: marimo
+      base_image: python-tensorflow
+      python_version_1: 3.13.13
+      python_version_2: 3.12.13
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ They can be used alone but are designed to work with the [Onyxia](https://github
       PYDS--> VSCODEPYDS[vscode-python]:::ide;
       PYTENSORFLOW--> VSCODEPYTENSORFLOW[vscode-tensorflow]:::ide;
       PYTORCH--> VSCODEPYTORCH[vscode-pytorch]:::ide;
+      PYDS--> MARIMOPYDS[marimo-python]:::ide;
+      PYSPARK--> MARIMOPYSPARK[marimo-pyspark]:::ide;
+      PYTORCH--> MARIMOPYTORCH[marimo-pytorch]:::ide;
+      PYTENSORFLOW--> MARIMOPYTENSORFLOW[marimo-tensorflow]:::ide;
       RSPARK -->RSTUDIOSPARKR[rstudio-sparkr]:::ide;
       RDS--> RSTUDIORDS[rstudio-r]:::ide;
       RPYJU--> JRPYJU[jupyter-r-python-julia]:::ide;

--- a/marimo/Dockerfile
+++ b/marimo/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE=inseefrlab/onyxia-python-datascience
+FROM $BASE_IMAGE
+
+LABEL maintainer="InseeFrLab <innovation@insee.fr>"
+
+COPY --chmod=0755 scripts/ /opt/
+RUN /opt/install-marimo.sh && \
+    # Clean
+    /opt/clean.sh
+
+USER 1000
+
+EXPOSE 2718
+
+CMD ["marimo", "edit", "--host", "0.0.0.0"]

--- a/marimo/scripts/install-marimo.sh
+++ b/marimo/scripts/install-marimo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Install marimo
+uv pip install --system --no-cache marimo
+
+# Clean install files
+rm -rf $HOME/.cache

--- a/marimo/tests.yaml
+++ b/marimo/tests.yaml
@@ -1,0 +1,39 @@
+schemaVersion: "2.0.0"
+metadataTest:
+  user: 1000
+  workdir: "/home/onyxia/work"
+  exposedPorts: ["2718"]
+fileExistenceTests:
+  - name: "user home"
+    path: "/home/onyxia"
+    shouldExist: true
+    permissions: "drwxr-x---"
+    uid: 1000
+    gid: 100
+  - name: "onyxia init script"
+    path: "/opt/onyxia-init.sh"
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
+    uid: 1000
+    gid: 100
+commandTests:
+  - name: "Does the binary exists?"
+    command: "which"
+    args: ["helm"]
+    expectedOutput: ["/usr/local/bin/helm"]
+  - name: "Does the binary exists?"
+    command: "which"
+    args: ["kubectl"]
+    expectedOutput: ["/usr/local/bin/kubectl"]
+  - name: "Does the binary exists?"
+    command: "which"
+    args: ["mc"]
+    expectedOutput: ["/usr/local/bin/mc"]
+  - name: "Does the binary exists?"
+    command: "which"
+    args: ["manimo"]
+    expectedOutput: ["/opt/python/bin/marimo"]
+  - name: "Does the binary exists?"
+    command: "which"
+    args: ["duckdb"]
+    expectedOutput: ["/usr/local/bin/duckdb"]


### PR DESCRIPTION
This PR introduces [Marimo](https://marimo.io/)  as a new IDE option in the images-datascience catalog.

Marimo is an open-source, reactive Python notebook that is reproducible, git-friendly, and can be deployed as an application. Including it provides users with a modern alternative to traditional Jupyter notebooks for data science workflows within the Onyxia ecosystem.

I've added what should be enough to build marimo in the CI, 14 new images to be created, sorry for the increased build time

PR to add marimo chart in the interactive services catalog to follow