### PR TITLE
Export REQUESTS_CA_BUNDLE in main script

### DIFF
--- a/base/scripts/onyxia-init.sh
+++ b/base/scripts/onyxia-init.sh
@@ -249,5 +249,11 @@ for f in "$ROOT_PROJECT_DIRECTORY"/*; do
     fi
 done
 
+# The AWS CLI apparently makes use of the $REQUESTS_CA_BUNDLE variable to configure the trust store.
+# In case one is configured for a service based on these images, the variable should be set accordingly.
+if [[ -n "$PATH_TO_CA_BUNDLE" ]]; then
+    export REQUESTS_CA_BUNDLE=$PATH_TO_CA_BUNDLE
+fi
+
 echo "execution of $@"
 exec "$@"

--- a/base/scripts/onyxia-set-repositories.sh
+++ b/base/scripts/onyxia-set-repositories.sh
@@ -14,7 +14,6 @@ if command -v pip &>/dev/null; then
         echo "configuration of python and pip to use a custom crt"
         pip config set global.cert $PATH_TO_CA_BUNDLE
         python /opt/certifi_ca.py
-        export REQUESTS_CA_BUNDLE=$PATH_TO_CA_BUNDLE
     fi
 fi
 


### PR DESCRIPTION
The `REQUESTS_CA_BUNDLE` environment variable is presently set in the `onyxia-set-repositories.sh` file, which was fine as long as we thought it was only needed when configuring a custom trust store for Python environments.

But as it turns out, this variable is also used by the `aws` CLI for the same purpose of changing the default truststore. In other words, this means that when the S3 instance accessed from a service uses a certificate that requires a custom truststore, the `aws` cli only works out of the box on Python environments, and not RStudio.

This PR then suggests moving the export of that variable to the main `onyxia-init.sh` script, so it benefits every image.