### PR TITLE
fix(duckdb): change deprecated env var UV_NATIVE_TLS to UV_SYSTEM_CERTS

### DIFF
--- a/base/scripts/onyxia-set-repositories.sh
+++ b/base/scripts/onyxia-set-repositories.sh
@@ -20,7 +20,7 @@ fi
 if command -v uv &>/dev/null; then
     if [[ -n "$PIP_REPOSITORY" ]]; then
         echo "export UV_DEFAULT_INDEX=$PIP_REPOSITORY" >> "$ENV_FILE"
-        echo 'export UV_NATIVE_TLS=true' >> "$ENV_FILE"
+        echo 'export UV_SYSTEM_CERTS=true' >> "$ENV_FILE"
     fi
 fi
 


### PR DESCRIPTION
Fix the following warning when using `uv` : 

> warning: The `UV_NATIVE_TLS` environment variable is deprecated and will be removed in a future release. Use `UV_SYSTEM_CERTS` instead.